### PR TITLE
Undefine properties when removed from class

### DIFF
--- a/lib/class-helpers.js
+++ b/lib/class-helpers.js
@@ -1,3 +1,5 @@
+import { arr } from "lively.lang";
+
 export const initializeSymbol = Symbol.for("lively-instance-initialize"),
              instanceRestorerSymbol = Symbol.for("lively-instance-restorer"),
              superclassSymbol = Symbol.for("lively-instance-superclass"),
@@ -54,9 +56,10 @@ function installGetterSetterDescriptor(klass, descr) {
   Object.defineProperty(klass, descr.key, descr)
 }
 
-function addMethods(klass, instanceMethods, classMethods) {
+function installMethods(klass, instanceMethods, classMethods) {
   // install methods from two lists (static + instance) of {key, value} or
   // {key, get/set} descriptors
+  
   classMethods && classMethods.forEach(ea => {
     ea.value ?
       installValueDescriptor(klass, klass, ea) :
@@ -81,6 +84,16 @@ function addMethods(klass, instanceMethods, classMethods) {
     });
     klass.prototype[initializeSymbol].displayName = "lively-initialize";
   }
+  
+  // 5. undefine properties that were removed form class definition
+  const toDeleteInstance = lively.lang.arr.withoutAll(
+    Object.getOwnPropertyNames(klass.prototype),
+    instanceMethods.map(m => m.key).concat(["constructor"]));
+  toDeleteInstance.forEach(key => { delete klass.prototype[key]; });
+  const toDeleteClass = lively.lang.arr.withoutAll(
+    Object.getOwnPropertyNames(klass),
+    classMethods.map(m => m.key).concat(["length", "name", "prototype"]));
+  toDeleteClass.forEach(key => { delete klass[key]; });
 }
 
 
@@ -129,7 +142,7 @@ export function initializeClass(
   var superclass = setSuperclass(klass, superclassSpec);
 
   // 3. Install methods
-  addMethods(klass, instanceMethods, classMethods);
+  installMethods(klass, instanceMethods, classMethods);
 
   // 4. If we have a `currentModule` instance (from lively.modules/src/module.js)
   // then we also store some meta data about the module. This allows us to
@@ -155,7 +168,7 @@ export function initializeClass(
         if (name === superclassSpec.referencedAs) {
           // console.log(`class ${className}: new superclass ${name} ${name !== superclassSpec.referencedAs ? '(' + superclassSpec.referencedAs + ')' : ''}was defined via module bindings`)
           setSuperclass(klass, val);
-          addMethods(klass, instanceMethods, classMethods);
+          installMethods(klass, instanceMethods, classMethods);
         }
       });
     }

--- a/tests/class-helper-test.js
+++ b/tests/class-helper-test.js
@@ -135,6 +135,22 @@ describe("create or extend classes", function() {
     foo.m = () => 24;
     expect(foo.m()).equals(24);
   });
+  
+  it("overridden instance methods can be removed", async function() {
+    await evalClass("class Foo { m() { return 23; } }")
+    const Foo2 = await evalClass("class Foo2 extends Foo { m() { return 42; } }"),
+          foo = new Foo2();
+    expect(foo.m()).equals(42);
+    await evalClass("class Foo2 extends Foo { }");
+    expect(foo.m()).equals(23);
+  });
+
+  it("class methods can be removed", async function() {
+    const Foo = await evalClass("class Foo { static m() { return 23; } }")
+    expect(Foo.m()).equals(23);
+    await evalClass("class Foo { }");
+    expect(Foo.m).to.be.undefined
+  });
 
   describe("compat with conventional class function", () => {
 


### PR DESCRIPTION
This should fix [this issue](https://github.com/LivelyKernel/lively.modules/issues/35) from lively.modules.
